### PR TITLE
Reduce escaping in playbook command generation

### DIFF
--- a/aminatorplugins/provisioner/ansible.py
+++ b/aminatorplugins/provisioner/ansible.py
@@ -160,5 +160,5 @@ class AnsibleProvisionerPlugin(BaseProvisionerPlugin):
 @command()
 def run_ansible_playbook(inventory, extra_vars, playbook_dir, playbook):
     path = playbook_dir + '/' + playbook
-    return 'ansible-playbook -c local -i {0} -e \\\'ami=True {1}\\\' {2}'.format(inventory, extra_vars, path)
+    return 'ansible-playbook -c local -i {0} -e \'ami=True {1}\' {2}'.format(inventory, extra_vars, path)
 


### PR DESCRIPTION
too much escaping when generating ansible-playbook command, was causing the extra vars parsing to complain of missing quote close, IE:

2014-03-13 17:05:11 [DEBUG] [aminator.util.linux(119):monitor_command] status code: 1
2014-03-13 17:05:11 [CRITICAL] [aminator.plugins.provisioner.base(99):provision] Installation of aminator-ubuntu.yml failed: Traceback (most recent call last):
  File "/usr/bin/ansible-playbook", line 269, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/usr/bin/ansible-playbook", line 112, in main
    extra_vars = utils.combine_vars(extra_vars, utils.parse_kv(extra_vars_opt))
  File "/usr/lib/python2.7/dist-packages/ansible/utils/**init**.py", line 491, in parse_kv
    vargs = [x.decode('utf-8') for x in shlex.split(args, posix=True)]
  File "/usr/lib/python2.7/shlex.py", line 279, in split
    return list(lex)
  File "/usr/lib/python2.7/shlex.py", line 269, in next
    token = self.get_token()
  File "/usr/lib/python2.7/shlex.py", line 96, in get_token
    raw = self.read_token()
  File "/usr/lib/python2.7/shlex.py", line 172, in read_token
    raise ValueError, "No closing quotation"
ValueError: No closing quotation

This change fixes that.
