### PR TITLE
fixing distro mountpoint

### DIFF
--- a/aminatorplugins/provisioner/ansible.py
+++ b/aminatorplugins/provisioner/ansible.py
@@ -87,7 +87,7 @@ class AnsibleProvisionerPlugin(BaseProvisionerPlugin):
 
         config = self._config.plugins[self.full_name]
         playbooks_path_source = config.get('playbooks_path_source')
-        playbooks_path_dest = self._distro._mountpoint + config.get('playbooks_path_dest')
+        playbooks_path_dest = self._distro.root_mountspec.mountpoint + config.get('playbooks_path_dest')
         
         if not os.path.isdir(playbooks_path_source):
             log.critical("directory does not exist %s", playbooks_path_source)


### PR DESCRIPTION
The following was failing for me. ami-1234567890 is a bogus AMI id.

aminate -e ec2_ansible_linux -B ami-1234567890 --extra-vars "ansible_distribution=Ubuntu" \
--enhanced-networking \
--arch x86_64 \
--provisioner-ebs-type gp2 \
--register-ebs-type gp2 \
--vm-type hvm \
--partition 1 \
base-ubuntu.yml

runtime execution was complaining about missing attribute _mountpoint

I had to make this code change to make aminator plugin to work for me. I don't know how it is working for everyone else.
